### PR TITLE
Seeds verbose

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,3 +23,8 @@ N_USERS.times do
 end
 puts "#{N_USERS} additional users created."
 
+# Create a default user.
+user = User.new(email: "test@test.com", password: "testtest")
+user.skip_confirmation!
+user.save
+puts "Test user created (test@test.com / testtest)."

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,19 @@
 require 'random_data'
 
-# Create Wikis
-#50.times do
-#  Wiki.create!(
-#    title: RandomData.random_sentence,
-#    body: RandomData.random_paragraph
-#  )
-#end
-#wikis = Wiki.all
+N_WIKIS = 50
+N_USERS = 50
 
-50.times do
+# Create some wikis.
+N_WIKIS.times do
+ Wiki.create!(
+   title: RandomData.random_sentence,
+   body: RandomData.random_paragraph
+ )
+end
+puts "#{N_WIKIS} additional wikis created."
+
+# Create some users.
+N_USERS.times do
   user = User.new(
     email: RandomData.random_email,
     password: RandomData.random_word << RandomData.random_word << RandomData.random_word
@@ -17,3 +21,5 @@ require 'random_data'
   user.skip_confirmation!
   user.save!
 end
+puts "#{N_USERS} additional users created."
+


### PR DESCRIPTION
Hey @thomasjacobjr 

I refactored db/seeds.rb to show you how I would have it display insights about what was seeded, and I added a default user.

But what about creating _three_ default users instead, one per role? We could have:
- [ ] standard@test.com
- [ ] premium@test.com
- [ ] admin@test.com

With the same password (testtest), but different roles: Easy to remember, easy to use. How would you do that?

_Note: you should be able to `git checkout seeds-verbose` locally and work within that branch, including pushing to this very Pull Request. If git complains, run `git fetch origin` and retry checking out the branch._
